### PR TITLE
Fix cleanup path and ESM path resolution

### DIFF
--- a/executor/server.js
+++ b/executor/server.js
@@ -33,19 +33,19 @@ app.post('/run', (req, res) => {
     // 出力の最後に "TIME_MS:<実行時間> MEM:<メモリ使用量>" を出力するようにしている前提）
     exec(`./run.sh ${language} ${solutionPath}`, { cwd: tmpDir }, (error, stdout, stderr) => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
-          /* --- Windows の “EBUSY” 対策：リトライ付きで削除 ---------------- */
+        /* --- Windows の “EBUSY” 対策：リトライ付きで削除 ---------------- */
         const tryRemove = (retry = 3) => {
-               try {
-                   fs.rmSync(tcDir, { recursive: true, force: true });
-               } catch (e) {
-                     if ((e.code === 'EBUSY' || e.code === 'EPERM') && retry > 0) {
-                           setTimeout(() => tryRemove(retry - 1), 100);   // 100 ms 後に再試行
-                           return;
-                         }
-                     throw e;   // その他のエラーはそのまま投げる
-                   }
-             };
-         tryRemove();
+            try {
+                fs.rmSync(tmpDir, { recursive: true, force: true });
+            } catch (e) {
+                if ((e.code === 'EBUSY' || e.code === 'EPERM') && retry > 0) {
+                    setTimeout(() => tryRemove(retry - 1), 100);   // 100 ms 後に再試行
+                    return;
+                }
+                throw e;   // その他のエラーはそのまま投げる
+            }
+        };
+        tryRemove();
         if (error) {
             return res.status(500).json({ error: stderr || error.message });
         }

--- a/next-app/pages/api/submit.js
+++ b/next-app/pages/api/submit.js
@@ -9,6 +9,10 @@ import { exec } from 'child_process';
 import fs   from 'fs';
 import path from 'path';
 import os   from 'os';
+import { fileURLToPath } from 'url';
+
+// __dirname is not defined in ES module scope; recreate it for compatibility
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /* ---------- 共通ヘルパ ---------- */
 


### PR DESCRIPTION
## Summary
- fix missing `__dirname` in `submit.js` for ESM
- clean up temporary directory correctly in `executor/server.js`

## Testing
- `node next-app/pages/api/submit.test.js > /tmp/out.txt && tail -n 5 /tmp/out.txt`

------
https://chatgpt.com/codex/tasks/task_e_684005c10224832baa612a5dd1db1436